### PR TITLE
Replace the deprecated API password with token auth

### DIFF
--- a/packages/net/hass/files/functions.sh
+++ b/packages/net/hass/files/functions.sh
@@ -23,11 +23,11 @@ function post {
     payload=$1
     
     config_get hass_host global host
-    config_get hass_pw global pw
+    config_get hass_token global token
     
     resp=$(curl "$hass_host/api/services/device_tracker/see" -sfSX POST \
         -H 'Content-Type: application/json' \
-        -H "X-HA-Access: $hass_pw" \
+        -H "Authorization: Bearer $hass_token" \
         --data-binary "$payload" 2>&1)
     
     if [ $? -eq 0 ]; then

--- a/packages/net/hass/files/hass.conf
+++ b/packages/net/hass/files/hass.conf
@@ -1,5 +1,5 @@
 config hass 'global'
         option host 'ip.or.name.example:8123'
-        option pw ''
+        option token ''
         option timeout_conn '24:00'
         option timeout_disc '00:03'


### PR DESCRIPTION
The API password mechanic is now deprecated since the new auth system has been merged.
This PR make use of (potentially long lived) access tokens.

https://developers.home-assistant.io/docs/en/auth_api.html#long-lived-access-token