### PR TITLE
Test that $interface is not null.

### DIFF
--- a/packages/net/hass/files/hassd.sh
+++ b/packages/net/hass/files/hassd.sh
@@ -20,6 +20,7 @@ sync_state
 ubus listen ubus.object.add | \
 while read line ; do
     interface=$(echo "$line" | grep -o '"path":"hostapd\.[^"]*"' | cut -d '"' -f 4 | cut -d '.' -f 2)
+    test $interface
     if [ $? = 0 ]
     then
         logger -t $0 -p info "$interface is up, setting up hook"


### PR DESCRIPTION
The interface extraction line has always a `0` exit code because of the `cut` commands. 

This creates problems when not matching interfaces come up, such as `network.interface.loopback`. In this case `$interface` will be an empty string but the `[ $? = 0 ]` test will succeed. In turn `register_hook` is called with empty interface which exits with `exit 1`.

Adding a `test` for `$interface` fixes the problem.