### PR TITLE
Enhanced is_connected to avoid false positives

### DIFF
--- a/packages/net/hass/files/functions.sh
+++ b/packages/net/hass/files/functions.sh
@@ -76,7 +76,12 @@ function is_connected {
 
     for interface in `iw dev | grep Interface | cut -f 2 -s -d" "`; do
         if iw dev $interface station dump | grep Station | grep -q $mac; then
-            return 0
+			for ip in `ip neigh | grep $mac | awk '{print $1}'`; do
+				ping -c 1 $ip
+				if iw dev $interface station dump | grep Station | grep -q $mac; then
+					return 0
+				fi
+			done      
         fi
     done
 


### PR DESCRIPTION
Checking MAC addresses via `iw` has the disadvantage that clients are only removed after a timeout. To avoid a positive MAC check even though a device has been disconnected from all wlan interfaces the IPs (v4 & v6) associated with a MAC are found via `ip neigh` and a `ping` is issued to all IPs. After the `ping` disconnected MAC should be removed from the iw list and the `iw` check is repeated.