### PR TITLE
Fix syntax error in function declaration

### DIFF
--- a/packages/net/hass-tracker/files/functions.sh
+++ b/packages/net/hass-tracker/files/functions.sh
@@ -1,4 +1,4 @@
-err_msg {
+err_msg() {
     logger -t $0 -p error $@
     echo $1 1>&2
 }


### PR DESCRIPTION
Regression from d4e2a34aa3df98e20dfa5bb2c6a8e8601aad029c (https://github.com/mueslo/openwrt_hass_devicetracker/pull/33), which updated the function declarations but was missing `()` here.

Fixes https://github.com/mueslo/openwrt_hass_devicetracker/issues/38.