### PR TITLE
feat: Implement whitelist

### DIFF
--- a/packages/net/hass-tracker/files/hass-tracker.conf
+++ b/packages/net/hass-tracker/files/hass-tracker.conf
@@ -4,3 +4,4 @@ config hass-tracker 'global'
         option token ''
         option timeout_conn '24:00'
         option timeout_disc '00:03'
+#        option whitelist "host1.lan host2.lan"


### PR DESCRIPTION
There's the case that my home Wi-Fi contains many devices of different purposes, e.g. guest phone, TV stream box, IoT sensors and such. Those Wi-Fi clients shouldn't be reported as a device tracker, because we don't care about their connection status. So a whitelist function is implemented.