### PR TITLE
Add multiple features without breaking existed

### DIFF
--- a/packages/net/hass-tracker/files/hass-tracker.conf
+++ b/packages/net/hass-tracker/files/hass-tracker.conf
@@ -4,3 +4,4 @@ config hass-tracker 'global'
         option token ''
         option timeout_conn '24:00'
         option timeout_disc '00:03'
+#        option whitelist "host1.lan host2.lan"

--- a/packages/net/hass-tracker/files/hass-tracker.conf
+++ b/packages/net/hass-tracker/files/hass-tracker.conf
@@ -4,4 +4,5 @@ config hass-tracker 'global'
         option token ''
         option timeout_conn '24:00'
         option timeout_disc '00:03'
-#        option whitelist "host1.lan host2.lan"
+#        option whitelist "host1 host2"
+#        option curl_insecure 1


### PR DESCRIPTION
The modification is a bit messy so I combine the features inside one PR. 

-  Listen dnsmasq DHCP events, report to HA after IP and hostname present.
-  Currently the script get IP with MAC address from ARP cache. Add another way to get from DHCP leases as fallback.
-  Filter hostapd associate event, if hostname could not be found from nslookup or DHCP leases, ignore the event. (DHCP event will call the script, so no device will be missed)
-  Add whitelist option so non-related devices could be filtered out.

I didn't test the build. Only scp'ed the script with modified one a.nd it works..

Hopefully this could fix #37, fix #43, fix #8.